### PR TITLE
[BUGFIX] fix deprecation in php 8.4

### DIFF
--- a/Classes/Command/ConfigurationCommand.php
+++ b/Classes/Command/ConfigurationCommand.php
@@ -12,7 +12,7 @@ use T3\CliConfig\Service\ConfigurationService;
 
 class ConfigurationCommand extends Command
 {
-    public function __construct(private readonly ConfigurationService $configurationService, string $name = null)
+    public function __construct(private readonly ConfigurationService $configurationService, ?string $name = null)
     {
         parent::__construct($name);
     }


### PR DESCRIPTION
In PHP i got the deprecation error: 
 Deprecated: T3\CliConfig\Command\ConfigurationCommand::__construct(): Implicitly marking parameter $name as nullable is deprecated, the explicit nullable type must be used instead in /var/www/html/v13/vendor/t3/cli-config/Classes/Command/ConfigurationCommand.php on line 15